### PR TITLE
Thread Safety (WIP)

### DIFF
--- a/Applications/IRCClient/IRCClient.cpp
+++ b/Applications/IRCClient/IRCClient.cpp
@@ -519,7 +519,7 @@ void IRCClient::handle_rpl_topicwhotime(const Message& msg)
     bool ok;
     time_t setat_time = setat.to_uint(ok);
     if (ok) {
-        auto* tm = localtime(&setat_time);
+        auto* tm = localtime_r(&setat_time);
         setat = String::format("%4u-%02u-%02u %02u:%02u:%02u",
             tm->tm_year + 1900,
             tm->tm_mon + 1,

--- a/LibC/stdlib.cpp
+++ b/LibC/stdlib.cpp
@@ -374,7 +374,7 @@ char* mktemp(char* pattern)
 
     for (int attempt = 0; attempt < 100; ++attempt) {
         for (int i = 0; i < 6; ++i)
-            pattern[start + i] = random_characters[(rand() % sizeof(random_characters))];
+            pattern[start + i] = random_characters[(rand_r() % sizeof(random_characters))];
         struct stat st;
         int rc = lstat(pattern, &st);
         if (rc < 0 && errno == ENOENT)

--- a/LibC/string.cpp
+++ b/LibC/string.cpp
@@ -362,7 +362,7 @@ char* strpbrk(const char* s, const char* accept)
     return nullptr;
 }
 
-char *strtok(char* str, const char* delim)
+char *strtok_r(char* str, const char* delim)
 {
     (void)str;
     (void)delim;

--- a/LibC/unistd.cpp
+++ b/LibC/unistd.cpp
@@ -177,7 +177,7 @@ int ttyname_r(int fd, char* buffer, size_t size)
 }
 
 static char ttyname_buf[32];
-char* ttyname(int fd)
+char* ttyname_r(int fd)
 {
     if (ttyname_r(fd, ttyname_buf, sizeof(ttyname_buf)) < 0)
         return nullptr;
@@ -424,10 +424,10 @@ int seal_shared_buffer(int shared_buffer_id)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
-char* getlogin()
+char* getlogin_r()
 {
     static char __getlogin_buffer[256];
-    if (auto* passwd = getpwuid(getuid())) {
+    if (auto* passwd = getpwuid_r(getuid())) {
         strncpy(__getlogin_buffer, passwd->pw_name, sizeof(__getlogin_buffer));
         return __getlogin_buffer;
     }

--- a/Servers/WindowServer/WSWindowManager.cpp
+++ b/Servers/WindowServer/WSWindowManager.cpp
@@ -88,7 +88,7 @@ WSWindowManager::WSWindowManager()
     m_wallpaper_path = "/res/wallpapers/retro.rgb";
     m_wallpaper = GraphicsBitmap::load_from_file(GraphicsBitmap::Format::RGBA32, m_wallpaper_path, { 1024, 768 });
 
-    m_username = getlogin();
+    m_username = getlogin_r();
 
     m_menu_selection_color = Color::from_rgb(0x84351a);
 
@@ -900,7 +900,7 @@ void WSWindowManager::draw_menubar()
     m_back_painter->draw_text(username_rect, m_username, Font::default_bold_font(), TextAlignment::CenterRight, Color::Black);
 
     time_t now = time(nullptr);
-    auto* tm = localtime(&now);
+    auto* tm = localtime_r(&now);
     auto time_text = String::format("%4u-%02u-%02u %02u:%02u:%02u",
         tm->tm_year + 1900,
         tm->tm_mon + 1,

--- a/Userland/ls.cpp
+++ b/Userland/ls.cpp
@@ -168,7 +168,7 @@ int do_dir(const char* path)
         else
             printf(" %10u ", st.st_size);
 
-        auto* tm = localtime(&st.st_mtime);
+        auto* tm = localtime_r(&st.st_mtime);
         printf("  %4u-%02u-%02u %02u:%02u:%02u  ",
             tm->tm_year + 1900,
             tm->tm_mon + 1,

--- a/Userland/sh.cpp
+++ b/Userland/sh.cpp
@@ -245,7 +245,7 @@ int main(int argc, char** argv)
         perror("ttyname_r");
 
     {
-        auto* pw = getpwuid(getuid());
+        auto* pw = getpwuid_r(getuid());
         if (pw)
             g->username = pw->pw_name;
         endpwent();


### PR DESCRIPTION
Consider using EX: getlogin_r(...) instead of getlogin(...) for improved thread safety.

Much code has been originally written without consideration of multi-threading. Also, engineers were relying on their old experience; They had learned posix before threading extensions were added. This change guides the program to use thread-safe functions.