### PR TITLE
Some small toolchain script improvements

### DIFF
--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -63,6 +63,10 @@ mkdir -p $PREFIX
 mkdir -p "$DIR/Build/binutils"
 mkdir -p "$DIR/Build/gcc"
 
+if [ -z "$MAKEJOBS" ]; then
+    MAKEJOBS=$(nproc)
+fi
+
 pushd "$DIR/Build/"
     unset PKG_CONFIG_LIBDIR # Just in case
 
@@ -71,7 +75,7 @@ pushd "$DIR/Build/"
                                               --target=$TARGET \
                                               --with-sysroot=$SYSROOT \
                                               --disable-nls || exit 1
-        make -j $(nproc) || exit 1
+        make -j $MAKEJOBS || exit 1
         make install || exit 1
     popd
 
@@ -84,7 +88,7 @@ pushd "$DIR/Build/"
                                           --enable-languages=c,c++ || exit 1
 
         echo "XXX build gcc and libgcc"
-        make -j $(nproc) all-gcc all-target-libgcc || exit 1
+        make -j $MAKEJOBS all-gcc all-target-libgcc || exit 1
         echo "XXX install gcc and libgcc"
         make install-gcc install-target-libgcc || exit 1
 

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 echo $DIR

--- a/Toolchain/UseIt.sh
+++ b/Toolchain/UseIt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR=$( dirname $( readlink -e "$0" ) )
 export PATH="$DIR/Local/bin:$PATH"
 export TOOLCHAIN="$DIR"
 echo "$PATH"


### PR DESCRIPTION
    BuildIt: Allow specifying MAKEJOBS rather than forcing to nprocs
    UseIt: allow sourcing from outside the Toolchain dir
    BuildIt: use set -e to fail immediately on error
