### PR TITLE
LibC: Change putenv (and getenv) to not copy, but directly return the environ values.

### DIFF
--- a/LibC/crt0.cpp
+++ b/LibC/crt0.cpp
@@ -8,7 +8,7 @@ int main(int, char**);
 
 int errno;
 char** environ;
-//bool __environ_is_malloced;
+bool __environ_is_malloced;
 
 void __libc_init()
 {
@@ -22,7 +22,7 @@ void __libc_init()
 int _start(int argc, char** argv, char** env)
 {
     environ = env;
-    //__environ_is_malloced = false;
+    __environ_is_malloced = false;
 
     __libc_init();
 

--- a/LibC/stdio.cpp
+++ b/LibC/stdio.cpp
@@ -293,6 +293,8 @@ void rewind(FILE* stream)
 
 int dbgprintf(const char* fmt, ...)
 {
+    // if this fails, you're printing too early.
+    ASSERT(stddbg);
     va_list ap;
     va_start(ap, fmt);
     int ret = vfprintf(stddbg, fmt, ap);

--- a/LibC/stdlib.h
+++ b/LibC/stdlib.h
@@ -16,6 +16,7 @@ void free(void*);
 void* realloc(void *ptr, size_t);
 char* getenv(const char* name);
 int putenv(char*);
+int unsetenv(char*);
 int atoi(const char*);
 long atol(const char*);
 long long atoll(const char*);

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -80,6 +80,17 @@ static int sh_export(int argc, char** argv)
     return 0;
 }
 
+static int sh_unset(int argc, char** argv)
+{
+    if (argc != 2) {
+        fprintf(stderr, "usage: unset variable\n");
+        return 1;
+    }
+
+    unsetenv(argv[1]);
+    return 0;
+}
+
 static int sh_cd(int argc, char** argv)
 {
     char pathbuf[PATH_MAX];
@@ -165,6 +176,10 @@ static bool handle_builtin(int argc, char** argv, int& retval)
     }
     if (!strcmp(argv[0], "export")) {
         retval = sh_export(argc, argv);
+        return true;
+    }
+    if (!strcmp(argv[0], "unset")) {
+        retval = sh_unset(argc, argv);
         return true;
     }
     if (!strcmp(argv[0], "history")) {

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -70,7 +70,13 @@ static int sh_export(int argc, char** argv)
         fprintf(stderr, "usage: export variable=value\n");
         return 1;
     }
-    putenv(const_cast<char*>(String::format("%s=%s", parts[0].characters(), parts[1].characters()).characters()));
+
+    // FIXME: Yes, this leaks.
+    // Maybe LibCore should grow a CEnvironment which is secretly a map to char*,
+    // so it can keep track of the environment pointers as needed?
+    const auto& s = String::format("%s=%s", parts[0].characters(), parts[1].characters());
+    char *ev = strndup(s.characters(), s.length());
+    putenv(ev);
     return 0;
 }
 
@@ -408,7 +414,9 @@ int main(int argc, char** argv)
         if (pw) {
             g.username = pw->pw_name;
             g.home = pw->pw_dir;
-            putenv(const_cast<char*>(String::format("HOME=%s", pw->pw_dir).characters()));
+            const auto& s = String::format("HOME=%s", pw->pw_dir);
+            char *ev = strndup(s.characters(), s.length());
+            putenv(ev);
         }
         endpwent();
     }


### PR DESCRIPTION
This is in keeping with how putenv should function. It does mean that
the shell's export command now leaks, but that's not a difficult fix.

Contributes to #29.