### PR TITLE
The great argument parsing cleanup

### DIFF
--- a/AK/ArgsParser.cpp
+++ b/AK/ArgsParser.cpp
@@ -28,8 +28,8 @@ ArgsParser::Arg::Arg(const String& name, const String& value_name, const String&
     : name(name), description(description), value_name(value_name), required(required)
 {}
 
-ArgsParser::ArgsParser(const String& program_name, const String& prefix)
-    : m_program_name(program_name), m_prefix(prefix)
+ArgsParser::ArgsParser(const String& program_name)
+    : m_program_name(program_name), m_prefix("-")
 {}
 
 ArgsParserResult ArgsParser::parse(const int argc, const char** argv) 

--- a/AK/ArgsParser.cpp
+++ b/AK/ArgsParser.cpp
@@ -112,6 +112,12 @@ bool ArgsParser::check_required_args(const ArgsParserResult& res)
                 return false;
         }
     }
+
+    if (m_single_value_required) {
+        if (res.m_single_values.size() == 0)
+            return false;
+    }
+
     return true;
 }
 
@@ -133,6 +139,18 @@ void ArgsParser::add_arg(const String& name, const String& description)
 void ArgsParser::add_arg(const String& name, const String& value_name, const String& description)
 {
     m_args.set(name, Arg(name, value_name, description, false));
+}
+
+void ArgsParser::set_single_value(const String& name)
+{
+    m_single_value_name = name;
+    m_single_value_required = false;
+}
+
+void ArgsParser::set_required_single_value(const String& name)
+{
+    m_single_value_name = name;
+    m_single_value_required = true;
 }
 
 String ArgsParser::get_usage() const
@@ -161,6 +179,20 @@ String ArgsParser::get_usage() const
             sb.append("> ");
         else
             sb.append("] ");
+    }
+
+    if (m_single_value_name.length()) {
+        if (m_single_value_required)
+            sb.append("<");
+        else
+            sb.append("[");
+
+        sb.append(m_single_value_name);
+
+        if (m_single_value_required)
+            sb.append(">");
+        else
+            sb.append("]");
     }
 
     sb.append("\n");

--- a/AK/ArgsParser.cpp
+++ b/AK/ArgsParser.cpp
@@ -5,171 +5,177 @@
 
 namespace AK {
 
-    bool ArgsParserResult::is_present(const String& arg_name) const
-    {
-	return m_args.contains(arg_name);
+bool ArgsParserResult::is_present(const String& arg_name) const
+{
+    return m_args.contains(arg_name);
+}
+
+String ArgsParserResult::get(const String& arg_name) const
+{
+    return m_args.get(arg_name);
+}
+
+const Vector<String>& ArgsParserResult::get_single_values() const
+{
+    return m_single_values;
+}
+
+ArgsParser::Arg::Arg(const String& name, const String& description, bool required)
+    : name(name), description(description), required(required)
+{}
+
+ArgsParser::Arg::Arg(const String& name, const String& value_name, const String& description, bool required)
+    : name(name), description(description), value_name(value_name), required(required)
+{}
+
+ArgsParser::ArgsParser(const String& program_name, const String& prefix)
+    : m_program_name(program_name), m_prefix(prefix)
+{}
+
+ArgsParserResult ArgsParser::parse(const int argc, const char** argv) 
+{
+    ArgsParserResult res;
+
+    // We should have at least one parameter
+    if (argc < 2)
+        return {};
+
+    // We parse the first parameter at the index 1
+    if (parse_next_param(1, argv, argc - 1, res) != 0)
+        return {};
+
+    if (!check_required_args(res))
+        return {};
+
+    return res;
+}
+
+int ArgsParser::parse_next_param(const int index, const char** argv, const int params_left, ArgsParserResult& res) 
+{
+    if (params_left == 0)
+        return 0;
+
+    String param = argv[index];
+
+    // We check if the prefix is found at the beginning of the param name
+    if (is_param_valid(param)) {
+        auto prefix_length = m_prefix.length();
+        String param_name = param.substring(prefix_length, param.length() - prefix_length);
+
+        auto arg = m_args.find(param_name);
+        if (arg == m_args.end()) {
+            printf("Unknown arg \"");
+            if (!param_name.is_null())
+                printf("%s", param_name.characters());
+            printf("\"\n");
+            return -1;
+        }
+
+        // If this parameter must be followed by a value, we look for it
+        if (!arg->value.value_name.is_null()) {
+            if (params_left < 1) {
+                printf("Missing value for argument %s\n", arg->value.name.characters());
+                return -1;
+            }
+
+            String next = String(argv[index + 1]);
+
+            if (is_param_valid(next)) {
+                printf("Missing value for argument %s\n", arg->value.name.characters());
+                return -1;
+            }
+
+            res.m_args.set(arg->value.name, next);
+            return parse_next_param(index + 2, argv, params_left - 2, res);
+        }
+
+        // Single argument, not followed by a value
+        res.m_args.set(arg->value.name, "");
+        return parse_next_param(index + 1, argv, params_left - 1, res);
     }
 
-    String ArgsParserResult::get(const String& arg_name) const
-    {
-	return m_args.get(arg_name);
+    // Else, it's a value alone, a file name parameter for example
+    res.m_single_values.append(param);
+    return parse_next_param(index + 1, argv, params_left - 1, res);
+}
+
+bool ArgsParser::is_param_valid(const String& param_name)
+{
+    return param_name.substring(0, m_prefix.length()) == m_prefix;
+}
+
+bool ArgsParser::check_required_args(const ArgsParserResult& res)
+{
+    for (auto& it : m_args) {
+        if (it.value.required) {
+            if (!res.is_present(it.value.name))
+                return false;
+        }
+    }
+    return true;
+}
+
+void ArgsParser::add_arg(const String& name, const String& description, bool required)
+{
+    m_args.set(name, Arg(name, description, required));
+}
+
+void ArgsParser::add_arg(const String& name, const String& value_name, const String& description, bool required)
+{
+    m_args.set(name, Arg(name, value_name, description, required));
+}
+
+String ArgsParser::get_usage() const
+{
+    StringBuilder sb;
+
+    sb.append("usage : ");
+    sb.append(m_program_name);
+    sb.append(" ");
+
+    for (auto& it : m_args) {
+        if (it.value.required)
+            sb.append("<");
+        else
+            sb.append("[");
+
+        sb.append(m_prefix);
+        sb.append(it.value.name);
+
+        if (!it.value.value_name.is_null()) {
+            sb.append(" ");
+            sb.append(it.value.value_name);
+        }
+
+        if (it.value.required)
+            sb.append("> ");
+        else
+            sb.append("] ");
     }
 
-    const Vector<String>& ArgsParserResult::get_single_values() const
-    {
-	return m_single_values;
-    }
-  
-    ArgsParser::Arg::Arg(const String& name, const String& description, bool required)
-	: name(name), description(description), required(required) {}
-    
-    ArgsParser::Arg::Arg(const String& name, const String& value_name, const String& description, bool required)
-	: name(name), description(description), value_name(value_name), required(required) {}
+    sb.append("\n");
 
-    ArgsParser::ArgsParser(const String& program_name, const String& prefix)
-	: m_program_name(program_name), m_prefix(prefix) {}
+    for (auto& it : m_args) {
+        sb.append("    ");
+        sb.append(m_prefix);
+        sb.append(it.value.name);
 
-    ArgsParserResult ArgsParser::parse(const int argc, const char** argv) 
-    {
-	ArgsParserResult res;
+        if (!it.value.value_name.is_null()) {
+            sb.append(" ");
+            sb.append(it.value.value_name);
+        }
 
-	// We should have at least one parameter
-	if (argc < 2)
-	    return {};
-
-	// We parse the first parameter at the index 1
-	if (parse_next_param(1, argv, argc - 1, res) != 0)
-	    return {};
-
-	if (!check_required_args(res))
-	    return {};
-
-	return res;
+        sb.append(" : ");
+        sb.append(it.value.description);
+        sb.append("\n");
     }
 
-    int ArgsParser::parse_next_param(const int index, const char** argv, const int params_left, ArgsParserResult& res) 
-    {
-	if (params_left == 0)
-	    return 0;
+    return sb.to_string();
+}
 
-	String param = argv[index];
-	
-	// We check if the prefix is found at the beginning of the param name
-	if (is_param_valid(param)) {
-	    auto prefix_length = m_prefix.length();
-	    String param_name = param.substring(prefix_length, param.length() - prefix_length);
-	    
-	    auto arg = m_args.find(param_name);
-	    if (arg == m_args.end()) {
-		printf("Unknown arg \"");
-		if (!param_name.is_null())
-		    printf("%s", param_name.characters());
-		printf("\"\n");
-		return -1;
-	    }
+void ArgsParser::print_usage() const
+{
+    printf("%s\n", get_usage().characters());
+}
 
-	    // If this parameter must be followed by a value, we look for it
-	    if (!arg->value.value_name.is_null()) {
-		if (params_left < 1) {
-		    printf("Missing value for argument %s\n", arg->value.name.characters());
-		    return -1;
-		}
-
-		String next = String(argv[index + 1]);
-
-		if (is_param_valid(next)) {
-		    printf("Missing value for argument %s\n", arg->value.name.characters());
-		    return -1;
-		}
-
-		res.m_args.set(arg->value.name, next);
-
-		return parse_next_param(index + 2, argv, params_left - 2, res);
-	    }
-	    
-	    // Single argument, not followed by a value
-	    res.m_args.set(arg->value.name, "");
-	    
-	    return parse_next_param(index + 1, argv, params_left - 1, res);
-	}
-	
-	// Else, it's a value alone, a file name parameter for example
-	res.m_single_values.append(param);
-	
-	return parse_next_param(index + 1, argv, params_left - 1, res);
-    }
-
-    bool ArgsParser::is_param_valid(const String& param_name)
-    {
-	return param_name.substring(0, m_prefix.length()) == m_prefix;
-    }
-
-    bool ArgsParser::check_required_args(const ArgsParserResult& res)
-    {
-	for (auto& it : m_args) {
-	    if (it.value.required) {
-		if (!res.is_present(it.value.name))
-		    return false;
-	    }
-	}
-	return true;
-    }
-
-    void ArgsParser::add_arg(const String& name, const String& description, bool required)
-    {
-	m_args.set(name, Arg(name, description, required));
-    }
-
-    void ArgsParser::add_arg(const String& name, const String& value_name, const String& description, bool required)
-    {
-	m_args.set(name, Arg(name, value_name, description, required));
-    }
-
-    String ArgsParser::get_usage() const
-    {
-	StringBuilder sb;
-
-	sb.append("usage : ");
-	sb.append(m_program_name);
-	sb.append(" ");
-
-	for (auto& it : m_args) {
-	    if (it.value.required)
-		sb.append("<");
-	    else
-		sb.append("[");
-	    sb.append(m_prefix);
-	    sb.append(it.value.name);
-	    if (!it.value.value_name.is_null()) {
-		sb.append(" ");
-		sb.append(it.value.value_name);
-	    }
-	    if (it.value.required)
-		sb.append("> ");
-	    else
-		sb.append("] ");
-	}
-
-	sb.append("\n");
-
-	for (auto& it : m_args) {
-	    sb.append("    ");
-	    sb.append(m_prefix);
-	    sb.append(it.value.name);
-	    if (!it.value.value_name.is_null()) {
-		sb.append(" ");
-		sb.append(it.value.value_name);
-	    }
-	    sb.append(" : ");
-	    sb.append(it.value.description);
-	    sb.append("\n");
-	}
-
-	return sb.to_string();
-    }
-
-    void ArgsParser::print_usage() const
-    {
-	printf("%s\n", get_usage().characters());
-    }
 }

--- a/AK/ArgsParser.cpp
+++ b/AK/ArgsParser.cpp
@@ -115,14 +115,24 @@ bool ArgsParser::check_required_args(const ArgsParserResult& res)
     return true;
 }
 
-void ArgsParser::add_arg(const String& name, const String& description, bool required)
+void ArgsParser::add_required_arg(const String& name, const String& description)
 {
-    m_args.set(name, Arg(name, description, required));
+    m_args.set(name, Arg(name, description, true));
 }
 
-void ArgsParser::add_arg(const String& name, const String& value_name, const String& description, bool required)
+void ArgsParser::add_required_arg(const String& name, const String& value_name, const String& description)
 {
-    m_args.set(name, Arg(name, value_name, description, required));
+    m_args.set(name, Arg(name, value_name, description, true));
+}
+
+void ArgsParser::add_arg(const String& name, const String& description)
+{
+    m_args.set(name, Arg(name, description, false));
+}
+
+void ArgsParser::add_arg(const String& name, const String& value_name, const String& description)
+{
+    m_args.set(name, Arg(name, value_name, description, false));
 }
 
 String ArgsParser::get_usage() const

--- a/AK/ArgsParser.h
+++ b/AK/ArgsParser.h
@@ -34,8 +34,10 @@ public:
 
     ArgsParserResult parse(const int argc, const char** argv);
 
-    void add_arg(const String& name, const String& description, bool required);
-    void add_arg(const String& name, const String& value_name, const String& description, bool required);
+    void add_required_arg(const String& name, const String& description);
+    void add_required_arg(const String& name, const String& value_name, const String& description);
+    void add_arg(const String& name, const String& description);
+    void add_arg(const String& name, const String& value_name, const String& description);
     String get_usage() const;
     void print_usage() const;
 

--- a/AK/ArgsParser.h
+++ b/AK/ArgsParser.h
@@ -30,7 +30,7 @@ private:
 
 class ArgsParser {
 public:
-    ArgsParser(const String& program_name, const String& prefix);
+    ArgsParser(const String& program_name);
 
     ArgsParserResult parse(const int argc, const char** argv);
 

--- a/AK/ArgsParser.h
+++ b/AK/ArgsParser.h
@@ -38,6 +38,8 @@ public:
     void add_required_arg(const String& name, const String& value_name, const String& description);
     void add_arg(const String& name, const String& description);
     void add_arg(const String& name, const String& value_name, const String& description);
+    void set_single_value(const String& name);
+    void set_required_single_value(const String& name);
     String get_usage() const;
     void print_usage() const;
 
@@ -59,6 +61,8 @@ private:
 
     String m_program_name;
     String m_prefix;
+    String m_single_value_name;
+    bool m_single_value_required = false;
     HashMap<String, Arg> m_args;
 };
 

--- a/AK/ArgsParser.h
+++ b/AK/ArgsParser.h
@@ -38,8 +38,8 @@ public:
     void add_required_arg(const String& name, const String& value_name, const String& description);
     void add_arg(const String& name, const String& description);
     void add_arg(const String& name, const String& value_name, const String& description);
-    void set_single_value(const String& name);
-    void set_required_single_value(const String& name);
+    void add_single_value(const String& name);
+    void add_required_single_value(const String& name);
     String get_usage() const;
     void print_usage() const;
 
@@ -61,8 +61,12 @@ private:
 
     String m_program_name;
     String m_prefix;
-    String m_single_value_name;
-    bool m_single_value_required = false;
+
+    struct SingleArg {
+        String name;
+        bool required;
+    };
+    Vector<SingleArg> m_single_args;
     HashMap<String, Arg> m_args;
 };
 

--- a/AK/ArgsParser.h
+++ b/AK/ArgsParser.h
@@ -14,48 +14,50 @@
 */
 
 namespace AK {
-    class ArgsParserResult {
-    public:
-	bool is_present(const String& arg_name) const;
-	String get(const String& arg_name) const;
-	const Vector<String>& get_single_values() const;
 
-    private:
-	HashMap<String, String> m_args;
-	Vector<String> m_single_values;
+class ArgsParserResult {
+public:
+    bool is_present(const String& arg_name) const;
+    String get(const String& arg_name) const;
+    const Vector<String>& get_single_values() const;
 
-	friend class ArgsParser;
+private:
+    HashMap<String, String> m_args;
+    Vector<String> m_single_values;
+
+    friend class ArgsParser;
+};
+
+class ArgsParser {
+public:
+    ArgsParser(const String& program_name, const String& prefix);
+
+    ArgsParserResult parse(const int argc, const char** argv);
+
+    void add_arg(const String& name, const String& description, bool required);
+    void add_arg(const String& name, const String& value_name, const String& description, bool required);
+    String get_usage() const;
+    void print_usage() const;
+
+private:
+    struct Arg {
+        inline Arg() {}
+        Arg(const String& name, const String& description, bool required);
+        Arg(const String& name, const String& value_name, const String& description, bool required);
+
+        String name;
+        String description;
+        String value_name;
+        bool required;
     };
 
-    class ArgsParser {
-    public:
-	ArgsParser(const String& program_name, const String& prefix);
+    int parse_next_param(const int index, const char** argv, const int params_left, ArgsParserResult& res);
+    bool is_param_valid(const String& param_name);
+    bool check_required_args(const ArgsParserResult& res);
 
-	ArgsParserResult parse(const int argc, const char** argv);
+    String m_program_name;
+    String m_prefix;
+    HashMap<String, Arg> m_args;
+};
 
-	void add_arg(const String& name, const String& description, bool required);
-	void add_arg(const String& name, const String& value_name, const String& description, bool required);
-	String get_usage() const;
-	void print_usage() const;
-
-    private:
-	struct Arg {
-	    inline Arg() {}
-	    Arg(const String& name, const String& description, bool required);
-	    Arg(const String& name, const String& value_name, const String& description, bool required);
-
-	    String name;
-	    String description;
-	    String value_name;
-	    bool required;
-	};
-
-	int parse_next_param(const int index, const char** argv, const int params_left, ArgsParserResult& res);
-	bool is_param_valid(const String& param_name);
-	bool check_required_args(const ArgsParserResult& res);
-
-	String m_program_name;
-	String m_prefix;
-	HashMap<String, Arg> m_args;
-    };
 }

--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -78,8 +78,7 @@ AK_OBJS = \
     ../AK/StringBuilder.o \
     ../AK/StringView.o \
     ../AK/FileSystemPath.o \
-    ../AK/StdLibExtras.o \
-    ../AK/ArgsParser.o
+    ../AK/StdLibExtras.o
 
 CXX_OBJS = $(KERNEL_OBJS) $(VFS_OBJS) $(AK_OBJS)
 OBJS = $(CXX_OBJS) Boot/boot.ao

--- a/LibC/Makefile
+++ b/LibC/Makefile
@@ -7,8 +7,7 @@ AK_OBJS = \
     ../AK/StringBuilder.o \
     ../AK/FileSystemPath.o \
     ../AK/StdLibExtras.o \
-    ../AK/MappedFile.o \
-    ../AK/ArgsParser.o
+    ../AK/MappedFile.o
 
 LIBC_OBJS = \
        SharedBuffer.o \

--- a/LibCore/CArgsParser.cpp
+++ b/LibCore/CArgsParser.cpp
@@ -1,40 +1,38 @@
-#include "ArgsParser.h"
-#include "StringBuilder.h"
+#include "CArgsParser.h"
+#include <AK/StringBuilder.h>
 
 #include <stdio.h>
 
-namespace AK {
-
-bool ArgsParserResult::is_present(const String& arg_name) const
+bool CArgsParserResult::is_present(const String& arg_name) const
 {
     return m_args.contains(arg_name);
 }
 
-String ArgsParserResult::get(const String& arg_name) const
+String CArgsParserResult::get(const String& arg_name) const
 {
     return m_args.get(arg_name);
 }
 
-const Vector<String>& ArgsParserResult::get_single_values() const
+const Vector<String>& CArgsParserResult::get_single_values() const
 {
     return m_single_values;
 }
 
-ArgsParser::Arg::Arg(const String& name, const String& description, bool required)
+CArgsParser::Arg::Arg(const String& name, const String& description, bool required)
     : name(name), description(description), required(required)
 {}
 
-ArgsParser::Arg::Arg(const String& name, const String& value_name, const String& description, bool required)
+CArgsParser::Arg::Arg(const String& name, const String& value_name, const String& description, bool required)
     : name(name), description(description), value_name(value_name), required(required)
 {}
 
-ArgsParser::ArgsParser(const String& program_name)
+CArgsParser::CArgsParser(const String& program_name)
     : m_program_name(program_name), m_prefix("-")
 {}
 
-ArgsParserResult ArgsParser::parse(const int argc, const char** argv) 
+CArgsParserResult CArgsParser::parse(const int argc, const char** argv) 
 {
-    ArgsParserResult res;
+    CArgsParserResult res;
 
     // We should have at least one parameter
     if (argc < 2)
@@ -50,7 +48,7 @@ ArgsParserResult ArgsParser::parse(const int argc, const char** argv)
     return res;
 }
 
-int ArgsParser::parse_next_param(const int index, const char** argv, const int params_left, ArgsParserResult& res) 
+int CArgsParser::parse_next_param(const int index, const char** argv, const int params_left, CArgsParserResult& res) 
 {
     if (params_left == 0)
         return 0;
@@ -99,12 +97,12 @@ int ArgsParser::parse_next_param(const int index, const char** argv, const int p
     return parse_next_param(index + 1, argv, params_left - 1, res);
 }
 
-bool ArgsParser::is_param_valid(const String& param_name)
+bool CArgsParser::is_param_valid(const String& param_name)
 {
     return param_name.substring(0, m_prefix.length()) == m_prefix;
 }
 
-bool ArgsParser::check_required_args(const ArgsParserResult& res)
+bool CArgsParser::check_required_args(const CArgsParserResult& res)
 {
     for (auto& it : m_args) {
         if (it.value.required) {
@@ -128,32 +126,32 @@ bool ArgsParser::check_required_args(const ArgsParserResult& res)
     return true;
 }
 
-void ArgsParser::add_required_arg(const String& name, const String& description)
+void CArgsParser::add_required_arg(const String& name, const String& description)
 {
     m_args.set(name, Arg(name, description, true));
 }
 
-void ArgsParser::add_required_arg(const String& name, const String& value_name, const String& description)
+void CArgsParser::add_required_arg(const String& name, const String& value_name, const String& description)
 {
     m_args.set(name, Arg(name, value_name, description, true));
 }
 
-void ArgsParser::add_arg(const String& name, const String& description)
+void CArgsParser::add_arg(const String& name, const String& description)
 {
     m_args.set(name, Arg(name, description, false));
 }
 
-void ArgsParser::add_arg(const String& name, const String& value_name, const String& description)
+void CArgsParser::add_arg(const String& name, const String& value_name, const String& description)
 {
     m_args.set(name, Arg(name, value_name, description, false));
 }
 
-void ArgsParser::add_single_value(const String& name)
+void CArgsParser::add_single_value(const String& name)
 {
     m_single_args.append(SingleArg{name, false});
 }
 
-void ArgsParser::add_required_single_value(const String& name)
+void CArgsParser::add_required_single_value(const String& name)
 {
     if (m_single_args.size() != 0) {
         // adding required arguments after non-required arguments would be nonsensical
@@ -162,7 +160,7 @@ void ArgsParser::add_required_single_value(const String& name)
     m_single_args.append(SingleArg{name, true});
 }
 
-String ArgsParser::get_usage() const
+String CArgsParser::get_usage() const
 {
     StringBuilder sb;
 
@@ -224,9 +222,8 @@ String ArgsParser::get_usage() const
     return sb.to_string();
 }
 
-void ArgsParser::print_usage() const
+void CArgsParser::print_usage() const
 {
     printf("%s\n", get_usage().characters());
 }
 
-}

--- a/LibCore/CArgsParser.h
+++ b/LibCore/CArgsParser.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "AKString.h"
-#include "HashMap.h"
-#include "Vector.h"
+#include <AK/AKString.h>
+#include <AK/HashMap.h>
+#include <AK/Vector.h>
 
 /*
   The class ArgsParser provides a way to parse arguments by using a given list that describes the possible
@@ -13,9 +13,7 @@
   retrieve its value...). In case of error (missing required argument) an empty structure is returned as result.
 */
 
-namespace AK {
-
-class ArgsParserResult {
+class CArgsParserResult {
 public:
     bool is_present(const String& arg_name) const;
     String get(const String& arg_name) const;
@@ -25,14 +23,14 @@ private:
     HashMap<String, String> m_args;
     Vector<String> m_single_values;
 
-    friend class ArgsParser;
+    friend class CArgsParser;
 };
 
-class ArgsParser {
+class CArgsParser {
 public:
-    ArgsParser(const String& program_name);
+    CArgsParser(const String& program_name);
 
-    ArgsParserResult parse(const int argc, const char** argv);
+    CArgsParserResult parse(const int argc, const char** argv);
 
     void add_required_arg(const String& name, const String& description);
     void add_required_arg(const String& name, const String& value_name, const String& description);
@@ -55,9 +53,9 @@ private:
         bool required;
     };
 
-    int parse_next_param(const int index, const char** argv, const int params_left, ArgsParserResult& res);
+    int parse_next_param(const int index, const char** argv, const int params_left, CArgsParserResult& res);
     bool is_param_valid(const String& param_name);
-    bool check_required_args(const ArgsParserResult& res);
+    bool check_required_args(const CArgsParserResult& res);
 
     String m_program_name;
     String m_prefix;
@@ -70,4 +68,3 @@ private:
     HashMap<String, Arg> m_args;
 };
 
-}

--- a/LibCore/Makefile
+++ b/LibCore/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.common
 
 OBJS = \
+    CArgsParser.o \
     CIODevice.o \
     CFile.o \
     CSocket.o \

--- a/Userland/ln.cpp
+++ b/Userland/ln.cpp
@@ -1,34 +1,26 @@
 #include <stdio.h>
 #include <errno.h>
 #include <unistd.h>
-#include <getopt.h>
 #include <stdlib.h>
-
-[[noreturn]] static void print_usage_and_exit()
-{
-    printf("usage: ln [-s] <target> <link-path>\n");
-    exit(0);
-}
+#include <AK/ArgsParser.h>
 
 int main(int argc, char** argv)
 {
-    bool flag_symlink = false;
-    int opt;
-    while ((opt = getopt(argc, argv, "s")) != -1) {
-        switch (opt) {
-        case 's':
-            flag_symlink = true;
-            break;
-        default:
-            print_usage_and_exit();
-        }
+    AK::ArgsParser args_parser("ln");
+
+    args_parser.add_arg("s", "create a symlink");
+    args_parser.add_required_single_value("target");
+    args_parser.add_required_single_value("link-path");
+
+    AK::ArgsParserResult args = args_parser.parse(argc, (const char**)argv);
+    Vector<String> values = args.get_single_values();
+    if (values.size() == 0) {
+        args_parser.print_usage();
+        return 0;
     }
 
-    if ((optind + 1) >= argc)
-        print_usage_and_exit();
-
-    if (flag_symlink) {
-        int rc = symlink(argv[optind], argv[optind + 1]);
+    if (args.is_present("s")) {
+        int rc = symlink(values[0].characters(), values[1].characters());
         if (rc < 0) {
             perror("symlink");
             return 1;
@@ -36,7 +28,7 @@ int main(int argc, char** argv)
         return 0;
     }
 
-    int rc = link(argv[1], argv[2]);
+    int rc = link(values[0].characters(), values[1].characters());
     if (rc < 0) {
         perror("link");
         return 1;

--- a/Userland/ln.cpp
+++ b/Userland/ln.cpp
@@ -2,17 +2,17 @@
 #include <errno.h>
 #include <unistd.h>
 #include <stdlib.h>
-#include <AK/ArgsParser.h>
+#include <LibCore/CArgsParser.h>
 
 int main(int argc, char** argv)
 {
-    AK::ArgsParser args_parser("ln");
+    CArgsParser args_parser("ln");
 
     args_parser.add_arg("s", "create a symlink");
     args_parser.add_required_single_value("target");
     args_parser.add_required_single_value("link-path");
 
-    AK::ArgsParserResult args = args_parser.parse(argc, (const char**)argv);
+    CArgsParserResult args = args_parser.parse(argc, (const char**)argv);
     Vector<String> values = args.get_single_values();
     if (values.size() == 0) {
         args_parser.print_usage();

--- a/Userland/pape.cpp
+++ b/Userland/pape.cpp
@@ -6,10 +6,10 @@
 #include <fcntl.h>
 #include <dirent.h>
 #include <AK/AKString.h>
-#include <AK/ArgsParser.h>
 #include <AK/StringBuilder.h>
 #include <AK/Vector.h>
 #include <AK/FileSystemPath.h>
+#include <LibCore/CArgsParser.h>
 #include <LibGUI/GDesktop.h>
 #include <LibGUI/GApplication.h>
 
@@ -52,13 +52,13 @@ int main(int argc, char** argv)
 {
     GApplication app(argc, argv);
 
-    AK::ArgsParser args_parser("pape");
+    CArgsParser args_parser("pape");
 
     args_parser.add_arg("a", "show all wallpapers");
     args_parser.add_arg("c", "show current wallpaper");
     args_parser.add_single_value("name");
 
-    AK::ArgsParserResult args = args_parser.parse(argc, (const char**)argv);
+    CArgsParserResult args = args_parser.parse(argc, (const char**)argv);
 
     if (args.is_present("a"))
         return handle_show_all();

--- a/Userland/pape.cpp
+++ b/Userland/pape.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
 
     args_parser.add_arg("a", "show all wallpapers");
     args_parser.add_arg("c", "show current wallpaper");
-    args_parser.set_single_value("name");
+    args_parser.add_single_value("name");
 
     AK::ArgsParserResult args = args_parser.parse(argc, (const char**)argv);
 

--- a/Userland/pidof.cpp
+++ b/Userland/pidof.cpp
@@ -34,7 +34,7 @@ static int pid_of(const String& process_name, bool single_shot, bool omit_pid, p
 
 int main(int argc, char** argv)
 {
-    AK::ArgsParser args_parser("pidof", "-");
+    AK::ArgsParser args_parser("pidof");
 
     args_parser.add_arg("s", "Single shot - this instructs the program to only return one pid");
     args_parser.add_arg("o", "pid", "Tells pidof to omit processes with that pid. The special pid %PPID can be used to name the parent process of the pidof program.");

--- a/Userland/pidof.cpp
+++ b/Userland/pidof.cpp
@@ -3,9 +3,9 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <LibCore/CProcessStatisticsReader.h>
+#include <LibCore/CArgsParser.h>
 #include <AK/AKString.h>
 #include <AK/Vector.h>
-#include <AK/ArgsParser.h>
 #include <AK/HashMap.h>
 
 static int pid_of(const String& process_name, bool single_shot, bool omit_pid, pid_t pid)
@@ -34,12 +34,12 @@ static int pid_of(const String& process_name, bool single_shot, bool omit_pid, p
 
 int main(int argc, char** argv)
 {
-    AK::ArgsParser args_parser("pidof");
+    CArgsParser args_parser("pidof");
 
     args_parser.add_arg("s", "Single shot - this instructs the program to only return one pid");
     args_parser.add_arg("o", "pid", "Tells pidof to omit processes with that pid. The special pid %PPID can be used to name the parent process of the pidof program.");
 
-    AK::ArgsParserResult args = args_parser.parse(argc, (const char**)argv);
+    CArgsParserResult args = args_parser.parse(argc, (const char**)argv);
     
     bool s_arg = args.is_present("s");
     bool o_arg = args.is_present("o");

--- a/Userland/pidof.cpp
+++ b/Userland/pidof.cpp
@@ -35,10 +35,10 @@ static int pid_of(const String& process_name, bool single_shot, bool omit_pid, p
 int main(int argc, char** argv)
 {
     AK::ArgsParser args_parser("pidof", "-");
-    
-    args_parser.add_arg("s", "Single shot - this instructs the program to only return one pid", false);
-    args_parser.add_arg("o", "pid", "Tells pidof to omit processes with that pid. The special pid %PPID can be used to name the parent process of the pidof program.", false);
-    
+
+    args_parser.add_arg("s", "Single shot - this instructs the program to only return one pid");
+    args_parser.add_arg("o", "pid", "Tells pidof to omit processes with that pid. The special pid %PPID can be used to name the parent process of the pidof program.");
+
     AK::ArgsParserResult args = args_parser.parse(argc, (const char**)argv);
     
     bool s_arg = args.is_present("s");

--- a/Userland/sysctl.cpp
+++ b/Userland/sysctl.cpp
@@ -3,81 +3,11 @@
 #include <dirent.h>
 #include <errno.h>
 #include <string.h>
-#include <getopt.h>
 #include <fcntl.h>
+#include <AK/ArgsParser.h>
 #include <AK/AKString.h>
 #include <AK/StringBuilder.h>
 #include <AK/Vector.h>
-
-static bool flag_show_all = false;
-static int show_all();
-static int handle_var(const char*);
-
-static void usage()
-{
-    printf("usage: sysctl [-a] [variable[=value]]\n");
-}
-
-int main(int argc, char** argv)
-{
-    int opt;
-    while ((opt = getopt(argc, argv, "a")) != -1) {
-        switch (opt) {
-        case 'a':
-            flag_show_all = true;
-            break;
-        default:
-            usage();
-            return 0;
-        }
-    }
-
-    if (flag_show_all)
-        return show_all();
-
-    if (optind >= argc) {
-        usage();
-        return 0;
-    }
-
-    const char* var = argv[optind];
-
-    return handle_var(var);
-}
-
-int show_all()
-{
-    DIR* dirp = opendir("/proc/sys");
-    if (!dirp) {
-        perror("opendir");
-        return 1;
-    }
-    char pathbuf[PATH_MAX];
-
-    while (auto* de = readdir(dirp)) {
-        if (de->d_name[0] == '.')
-            continue;
-        sprintf(pathbuf, "/proc/sys/%s", de->d_name);
-        int fd = open(pathbuf, O_RDONLY);
-        if (fd < 0) {
-            perror("open");
-            continue;
-        }
-        char buffer[1024];
-        int nread = read(fd, buffer, sizeof(buffer));
-        close(fd);
-        if (nread < 0) {
-            perror("read");
-            continue;
-        }
-        buffer[nread] = '\0';
-        printf("%s = %s", de->d_name, buffer);
-        if (nread && buffer[nread - 1] != '\n')
-            printf("\n");
-    }
-    closedir(dirp);
-    return 0;
-}
 
 static String read_var(const String& name)
 {
@@ -119,9 +49,44 @@ static void write_var(const String& name, const String& value)
     close(fd);
 }
 
-int handle_var(const char* var)
+
+static int handle_show_all()
 {
-    String spec(var, Chomp);
+    DIR* dirp = opendir("/proc/sys");
+    if (!dirp) {
+        perror("opendir");
+        return 1;
+    }
+    char pathbuf[PATH_MAX];
+
+    while (auto* de = readdir(dirp)) {
+        if (de->d_name[0] == '.')
+            continue;
+        sprintf(pathbuf, "/proc/sys/%s", de->d_name);
+        int fd = open(pathbuf, O_RDONLY);
+        if (fd < 0) {
+            perror("open");
+            continue;
+        }
+        char buffer[1024];
+        int nread = read(fd, buffer, sizeof(buffer));
+        close(fd);
+        if (nread < 0) {
+            perror("read");
+            continue;
+        }
+        buffer[nread] = '\0';
+        printf("%s = %s", de->d_name, buffer);
+        if (nread && buffer[nread - 1] != '\n')
+            printf("\n");
+    }
+    closedir(dirp);
+    return 0;
+}
+
+static int handle_var(const String& var)
+{
+    String spec(var.characters(), Chomp);
     auto parts = spec.split('=');
     String variable_name = parts[0];
     bool is_write = parts.size() > 1;
@@ -136,3 +101,24 @@ int handle_var(const char* var)
     printf(" -> %s\n", read_var(variable_name).characters());
     return 0;
 }
+
+int main(int argc, char** argv)
+{
+    AK::ArgsParser args_parser("sysctl");
+
+    args_parser.add_arg("a", "show all variables");
+    args_parser.set_single_value("variable=[value]");
+
+    AK::ArgsParserResult args = args_parser.parse(argc, (const char**)argv);
+
+    if (args.is_present("a")) {
+        return handle_show_all();
+    } else if (args.get_single_values().size() != 1) {
+        args_parser.print_usage();
+        return 0;
+    }
+
+    Vector<String> values = args.get_single_values();
+    return handle_var(values[0]);
+}
+

--- a/Userland/sysctl.cpp
+++ b/Userland/sysctl.cpp
@@ -4,10 +4,10 @@
 #include <errno.h>
 #include <string.h>
 #include <fcntl.h>
-#include <AK/ArgsParser.h>
 #include <AK/AKString.h>
 #include <AK/StringBuilder.h>
 #include <AK/Vector.h>
+#include <LibCore/CArgsParser.h>
 
 static String read_var(const String& name)
 {
@@ -104,12 +104,12 @@ static int handle_var(const String& var)
 
 int main(int argc, char** argv)
 {
-    AK::ArgsParser args_parser("sysctl");
+    CArgsParser args_parser("sysctl");
 
     args_parser.add_arg("a", "show all variables");
     args_parser.add_single_value("variable=[value]");
 
-    AK::ArgsParserResult args = args_parser.parse(argc, (const char**)argv);
+    CArgsParserResult args = args_parser.parse(argc, (const char**)argv);
 
     if (args.is_present("a")) {
         return handle_show_all();

--- a/Userland/sysctl.cpp
+++ b/Userland/sysctl.cpp
@@ -107,7 +107,7 @@ int main(int argc, char** argv)
     AK::ArgsParser args_parser("sysctl");
 
     args_parser.add_arg("a", "show all variables");
-    args_parser.set_single_value("variable=[value]");
+    args_parser.add_single_value("variable=[value]");
 
     AK::ArgsParserResult args = args_parser.parse(argc, (const char**)argv);
 

--- a/Userland/tail.cpp
+++ b/Userland/tail.cpp
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
 
     args_parser.add_arg("f", "follow -- appended data is output as it is written to the file");
     args_parser.add_arg("n", "lines", "fetch the specified number of lines");
-    args_parser.set_required_single_value("file");
+    args_parser.add_required_single_value("file");
 
     AK::ArgsParserResult args = args_parser.parse(argc, (const char**)argv);
 

--- a/Userland/tail.cpp
+++ b/Userland/tail.cpp
@@ -4,8 +4,8 @@
 #include <errno.h>
 #include <unistd.h>
 #include <AK/Assertions.h>
-#include <AK/ArgsParser.h>
 #include <LibCore/CFile.h>
+#include <LibCore/CArgsParser.h>
 
 int tail_from_pos(CFile& file, off_t startline, bool want_follow)
 {
@@ -75,13 +75,13 @@ static void exit_because_we_wanted_lines()
 
 int main(int argc, char *argv[])
 {
-    AK::ArgsParser args_parser("tail");
+    CArgsParser args_parser("tail");
 
     args_parser.add_arg("f", "follow -- appended data is output as it is written to the file");
     args_parser.add_arg("n", "lines", "fetch the specified number of lines");
     args_parser.add_required_single_value("file");
 
-    AK::ArgsParserResult args = args_parser.parse(argc, (const char**)argv);
+    CArgsParserResult args = args_parser.parse(argc, (const char**)argv);
 
     Vector<String> values = args.get_single_values();
     if (values.size() != 1) {


### PR DESCRIPTION
Everything in Userland is now using ArgsParser for argument parsing, no exceptions. :)

This required adding some API to ArgsParser to handle optional/required single arguments (to make help pretty and useful), and as a drive-by I also did some style cleanup to ArgsParser to remove tabs etc.

Finally, ArgsParser is now renamed to CArgsParser, and lives in LibCore, not AK -- as the kernel won't ever make use of this.