### PR TITLE
Improve the handling of badly behaving WS clients

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -25,6 +25,7 @@
 #include <Kernel/SharedMemory.h>
 #include <Kernel/ProcessTracer.h>
 
+//#define DEBUG_POLL_SELECT
 //#define DEBUG_IO
 //#define TASK_DEBUG
 //#define FORK_DEBUG
@@ -1798,7 +1799,7 @@ int Process::sys$select(const Syscall::SC_select_params* params)
     if (error)
         return error;
 
-#ifdef DEBUG_IO
+#if defined(DEBUG_IO) || defined(DEBUG_POLL_SELECT)
     dbgprintf("%s<%u> selecting on (read:%u, write:%u), timeout=%p\n", name().characters(), pid(), current->m_select_read_fds.size(), current->m_select_write_fds.size(), timeout);
 #endif
 
@@ -1871,6 +1872,10 @@ int Process::sys$poll(pollfd* fds, int nfds, int timeout)
     } else {
         current->m_select_has_timeout = false;
     }
+
+#if defined(DEBUG_IO) || defined(DEBUG_POLL_SELECT)
+    dbgprintf("%s<%u> polling on (read:%u, write:%u), timeout=%d\n", name().characters(), pid(), current->m_select_read_fds.size(), current->m_select_write_fds.size(), timeout);
+#endif
 
     if (current->m_select_has_timeout || timeout < 0) {
         current->block(Thread::State::BlockedSelect);

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -853,8 +853,10 @@ ssize_t Process::sys$writev(int fd, const struct iovec* iov, int iov_count)
 ssize_t Process::do_write(FileDescriptor& descriptor, const byte* data, int data_size)
 {
     ssize_t nwritten = 0;
-    if (!descriptor.is_blocking())
-        return descriptor.write(data, data_size);
+    if (!descriptor.is_blocking()) {
+        if (!descriptor.can_write())
+            return -EAGAIN;
+    }
 
     while (nwritten < data_size) {
 #ifdef IO_DEBUG


### PR DESCRIPTION
Before, something that had a window and stopped reading mouse moves (for instance) would cause a panic because socket writes would go on unbounded until the kernel ran out of memory. That's bad.

So to fix that, we respect write buffers on the kernel side, and close WindowServer connections that fill up.

There is still a remaining bug in GEventLoop wherein read() returning EOF is only handled on the first loop through. I suspect there's a kernel bug in that read() when there is no data needs to be returning EAGAIN (and -1) rather than 0 (and thus EOF), but I haven't yet dug into that one.

And that one is arguably "tame" in that it just consumes all your available CPU endlessly polling the GEventLoop rather than killing your kernel.