### PR TITLE
Minesweeper: Make things a little more friendly at the start

### DIFF
--- a/Games/Minesweeper/Field.h
+++ b/Games/Minesweeper/Field.h
@@ -92,4 +92,5 @@ private:
     int m_flags_left { 0 };
     Face m_face { Face::Default };
     bool m_chord_preview { false };
+    bool m_first_click { true };
 };


### PR DESCRIPTION
Rather than having the first click hit a bomb, if the first click would
hit a bomb, instead, reset the game board.

This is a (sort of) feature of Windows minesweeper, and IMO makes
playing a bit more fun :-)