### PR TITLE
Kernel: Report EAGAIN from read() on a non-blocking socket if the buffer is empty

### DIFF
--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -153,10 +153,20 @@ bool LocalSocket::can_read(FileDescriptor& descriptor) const
 ssize_t LocalSocket::read(FileDescriptor& descriptor, byte* buffer, ssize_t size)
 {
     auto role = descriptor.socket_role();
-    if (role == SocketRole::Accepted)
+    if (role == SocketRole::Accepted) {
+        if (!descriptor.is_blocking()) {
+            if (m_for_server.is_empty())
+                return -EAGAIN;
+        }
         return m_for_server.read(buffer, size);
-    if (role == SocketRole::Connected)
+    }
+    if (role == SocketRole::Connected) {
+        if (!descriptor.is_blocking()) {
+            if (m_for_client.is_empty())
+                return -EAGAIN;
+        }
         return m_for_client.read(buffer, size);
+    }
     ASSERT_NOT_REACHED();
 }
 

--- a/Servers/WindowServer/WSEventLoop.cpp
+++ b/Servers/WindowServer/WSEventLoop.cpp
@@ -301,7 +301,7 @@ void WSEventLoop::drain_client(WSClientConnection& client)
         WSAPI_ClientMessage message;
         // FIXME: Don't go one message at a time, that's so much context switching, oof.
         ssize_t nread = read(client.fd(), &message, sizeof(WSAPI_ClientMessage));
-        if (nread == 0) {
+        if (nread == 0 || (nread == -1 && errno == EAGAIN)) {
             if (!messages_received)
                 post_event(client, make<WSClientDisconnectedNotification>(client.client_id()));
             break;


### PR DESCRIPTION
This is not EOF, and never should have been so -- can trip up other code
when porting.

Also updates LibGUI and WindowServer which both relied on the old
behaviour (and didn't work without changes). There may be others, but I
didn't run into them with a quick inspection.